### PR TITLE
Add COHP/COOP Analysis for ABACUS NAO Models

### DIFF
--- a/.github/workflows/build_with_hash.yml
+++ b/.github/workflows/build_with_hash.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install Build Tools
         run: |
-          python -m pip install build cibuildwheel
+          python -m pip install build "cibuildwheel<4"
 
       - name: Build Source Distribution (sdist)
         run: |
@@ -86,4 +86,3 @@ jobs:
           path: |
             dist/*.whl
           overwrite: false
-

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install Build Tools
         run: |
-          python -m pip install build cibuildwheel
+          python -m pip install build "cibuildwheel<4"
 
       - name: Build Source Distribution (sdist)
         run: |

--- a/doc/source/functions/cohp.md
+++ b/doc/source/functions/cohp.md
@@ -1,0 +1,58 @@
+# COHP
+
+The COHP function evaluates atom-pair crystal orbital Hamilton population
+spectra from the ABACUS Hamiltonian matrix, overlap matrix and NAO
+eigenvectors already used by PyATB.
+
+The implemented value for one band and one k point is
+
+```text
+sum_ij Re[ C_i,n(k)^* M_ij(k) C_j,n(k) ]
+```
+
+where `M` is `H(k)` for COHP and `S(k)` for COOP. The selected orbital sets
+belong to two atom indices in the ABACUS `STRU` file. The spectrum is broadened
+on an energy grid with the same Gaussian smearing convention used by the PyATB
+PDOS/JDOS modules.
+
+## Input block
+
+```text
+COHP
+{
+    stru_file          STRU
+    atom_i_index      1
+    atom_j_index      2
+    atom_i_orbs       all
+    atom_j_orbs       2p
+    method            COHP
+    spin              sum
+    e_range           -8.0 8.0
+    de                0.02
+    sigma             0.08
+    invert            1
+    shift_to_efermi   1
+    output_prefix     COHP
+    kpoint_mode       mp
+    mp_grid           8 8 8
+}
+```
+
+`atom_i_orbs` and `atom_j_orbs` accept `all`, shell selectors such as `s`,
+`p`, `d`, `2p`, or comma/space separated global orbital indices. Atom indices
+are 1-based and follow the atom order in `STRU`.
+
+## Output
+
+The output directory is `Out/COHP`. The main spectrum is written to
+`COHP.dat` by default, with columns `energy_eV` and `COHP`. If
+`shift_to_efermi` is set to `1`, the energy axis is `E - E_F`.
+
+`COHP.meta.json` records the selected atoms, selected global orbital indices,
+orbital shell mapping and output file names. `plot_cohp.py` is generated in the
+same directory.
+
+## Notes
+
+COHP currently supports `nspin = 1` and collinear `nspin = 2`. For spin-polarized
+data, set `spin` to `sum`, `up`, or `down`.

--- a/doc/source/functions/cohp.md
+++ b/doc/source/functions/cohp.md
@@ -33,14 +33,25 @@ COHP
     invert            1
     shift_to_efermi   1
     output_prefix     COHP
+    input_file        Input
+    orbital_dir       basis
     kpoint_mode       mp
     mp_grid           8 8 8
 }
 ```
 
 `atom_i_orbs` and `atom_j_orbs` accept `all`, shell selectors such as `s`,
-`p`, `d`, `2p`, or comma/space separated global orbital indices. Atom indices
-are 1-based and follow the atom order in `STRU`.
+`p`, `d`, shell-like aliases such as `2s`, `2p`, `3d`, or comma/space
+separated global orbital indices. The numeric prefix is currently treated only
+as an angular-momentum alias: for example, `2p` is equivalent to `p`. It does
+not select a distinct radial shell. Atom indices are 1-based and follow the
+atom order in `STRU`.
+
+`orbital_dir` points to the directory containing ABACUS numerical orbital
+files. If `orbital_dir` is omitted, COHP tries to read `orbital_dir` from
+`input_file`; when the COHP block omits `input_file`, PyATB passes the running
+`Input` file path. If neither source gives an orbital directory, COHP falls
+back to the directory containing `STRU`.
 
 ## Output
 
@@ -50,7 +61,7 @@ The output directory is `Out/COHP`. The main spectrum is written to
 
 `COHP.meta.json` records the selected atoms, selected global orbital indices,
 orbital shell mapping and output file names. `plot_cohp.py` is generated in the
-same directory.
+same directory and can be run explicitly to create `cohp.pdf`.
 
 ## Notes
 

--- a/doc/source/functions/index.rst
+++ b/doc/source/functions/index.rst
@@ -12,6 +12,7 @@ Functions
    fermi_surface
    find_nodes
    pdos
+   cohp
    fat_band
    spin_texture
    wilson_loop

--- a/doc/source/input/input_keywords.md
+++ b/doc/source/input/input_keywords.md
@@ -32,6 +32,10 @@
 
   [stru_file](#stru_file-pdos_stru_file) | [e_range](#e_range-pdos_e_range) | [de](#de-pdos_de) | [sigma](#sigma-pdos_sigma) | [kpoint_mode](#kpoint_mode-pdos_kpoint_mode)
 
+- [COHP](#cohp)
+
+  [stru_file](#stru_file-cohp_stru_file) | [atom_i_index](#atom_i_index-cohp_atom_i_index) | [atom_j_index](#atom_j_index-cohp_atom_j_index) | [atom_i_orbs](#atom_i_orbs-cohp_atom_i_orbs) | [atom_j_orbs](#atom_j_orbs-cohp_atom_j_orbs) | [method](#method-cohp_method) | [spin](#spin-cohp_spin) | [e_range](#e_range-cohp_e_range) | [de](#de-cohp_de) | [sigma](#sigma-cohp_sigma) | [kpoint_mode](#kpoint_mode-cohp_kpoint_mode)
+
 - [FAT_BAND](#fat_band)
 
   [band_range](#band_range-fatband_band_range) | [stru_file](#stru_file-fatband_stru_file) | [kpoint_mode](#kpoint_mode-fatband_kpoint_mode)

--- a/doc/source/input/input_keywords.md
+++ b/doc/source/input/input_keywords.md
@@ -34,7 +34,7 @@
 
 - [COHP](#cohp)
 
-  [stru_file](#stru_file-cohp_stru_file) | [atom_i_index](#atom_i_index-cohp_atom_i_index) | [atom_j_index](#atom_j_index-cohp_atom_j_index) | [atom_i_orbs](#atom_i_orbs-cohp_atom_i_orbs) | [atom_j_orbs](#atom_j_orbs-cohp_atom_j_orbs) | [method](#method-cohp_method) | [spin](#spin-cohp_spin) | [e_range](#e_range-cohp_e_range) | [de](#de-cohp_de) | [sigma](#sigma-cohp_sigma) | [kpoint_mode](#kpoint_mode-cohp_kpoint_mode)
+  [stru_file](#stru_file-cohp_stru_file) | [atom_i_index](#atom_i_index-cohp_atom_i_index) | [atom_j_index](#atom_j_index-cohp_atom_j_index) | [atom_i_orbs](#atom_i_orbs-cohp_atom_i_orbs) | [atom_j_orbs](#atom_j_orbs-cohp_atom_j_orbs) | [method](#method-cohp_method) | [spin](#spin-cohp_spin) | [e_range](#e_range-cohp_e_range) | [de](#de-cohp_de) | [sigma](#sigma-cohp_sigma) | [invert](#invert-cohp_invert) | [shift_to_efermi](#shift_to_efermi-cohp_shift_to_efermi) | [output_prefix](#output_prefix-cohp_output_prefix) | [input_file](#input_file-cohp_input_file) | [orbital_dir](#orbital_dir-cohp_orbital_dir) | [kpoint_mode](#kpoint_mode-cohp_kpoint_mode)
 
 - [FAT_BAND](#fat_band)
 
@@ -424,6 +424,104 @@
 - **Default**: 0.001
 
 ### kpoint_mode {#pdos_kpoint_mode}
+
+- **Type**: String
+- **Description**: Used to set the k point. See [Setting of k points](#setting-of-k-points)
+- **Default**: No default value
+
+## COHP
+
+### stru_file {#cohp_stru_file}
+
+- **Type**: String
+- **Description**: ABACUS `STRU` file used to resolve atom order and numerical orbital files.
+- **Default**: No default value
+
+### atom_i_index {#cohp_atom_i_index}
+
+- **Type**: Integer
+- **Description**: First atom index in the ABACUS `STRU` atom order. Indices are 1-based.
+- **Default**: -1
+
+### atom_j_index {#cohp_atom_j_index}
+
+- **Type**: Integer
+- **Description**: Second atom index in the ABACUS `STRU` atom order. Indices are 1-based.
+- **Default**: -1
+
+### atom_i_orbs {#cohp_atom_i_orbs}
+
+- **Type**: String
+- **Description**: Orbital selector for `atom_i_index`. Accepts `all`, angular-momentum selectors such as `s`, `p`, `d`, shell-like aliases such as `2p`, or global orbital indices separated by spaces or commas.
+- **Default**: all
+
+### atom_j_orbs {#cohp_atom_j_orbs}
+
+- **Type**: String
+- **Description**: Orbital selector for `atom_j_index`. The syntax is the same as `atom_i_orbs`.
+- **Default**: all
+
+### method {#cohp_method}
+
+- **Type**: String
+- **Description**: Population method. `COHP` uses the Hamiltonian matrix and `COOP` uses the overlap matrix.
+- **Default**: COHP
+
+### spin {#cohp_spin}
+
+- **Type**: String
+- **Description**: Spin channel to output. Use `sum`, `up`, or `down`; `up` and `down` require `nspin = 2`.
+- **Default**: sum
+
+### e_range {#cohp_e_range}
+
+- **Type**: Real
+- **Description**: Energy range in eV before optional Fermi-energy shifting. Provide start and end values.
+- **Default**: `fermi_energy - 10.0` to `fermi_energy + 10.0`
+
+### de {#cohp_de}
+
+- **Type**: Real
+- **Description**: Energy-grid spacing in eV.
+- **Default**: 0.05
+
+### sigma {#cohp_sigma}
+
+- **Type**: Real
+- **Description**: Gaussian smearing width in eV.
+- **Default**: 0.15
+
+### invert {#cohp_invert}
+
+- **Type**: Boolean
+- **Description**: When set to `1`, multiply the population by `-1` so bonding contributions are positive in the common `-COHP` convention.
+- **Default**: 1
+
+### shift_to_efermi {#cohp_shift_to_efermi}
+
+- **Type**: Boolean
+- **Description**: When set to `1`, write output energies as `E - E_F`.
+- **Default**: 1
+
+### output_prefix {#cohp_output_prefix}
+
+- **Type**: String
+- **Description**: Prefix for the COHP data and metadata files written under `Out/COHP`.
+- **Default**: COHP
+
+### input_file {#cohp_input_file}
+
+- **Type**: String
+- **Description**: ABACUS `INPUT` file used to discover `orbital_dir` when `orbital_dir` is not set explicitly. If omitted, PyATB uses the running `Input` file path.
+- **Default**: Omitted
+
+### orbital_dir {#cohp_orbital_dir}
+
+- **Type**: String
+- **Description**: Directory containing ABACUS numerical orbital files. This value has priority over `orbital_dir` parsed from `input_file`; if neither is available, the `STRU` directory is used.
+- **Default**: Omitted
+
+### kpoint_mode {#cohp_kpoint_mode}
 
 - **Type**: String
 - **Description**: Used to set the k point. See [Setting of k points](#setting-of-k-points)

--- a/examples/Si2/pyatb/Input_cohp
+++ b/examples/Si2/pyatb/Input_cohp
@@ -1,0 +1,40 @@
+INPUT_PARAMETERS
+{
+    nspin               1
+    package             ABACUS
+    fermi_energy        6.389728305291531
+    fermi_energy_unit   eV
+    HR_route            data-HR-sparse_SPIN0.csr
+    SR_route            data-SR-sparse_SPIN0.csr
+    HR_unit             Ry
+    sparse_format       1
+}
+
+LATTICE
+{
+    lattice_constant        1.8897162
+    lattice_constant_unit   Bohr
+    lattice_vector
+    0.000000000000  2.715000000000  2.715000000000
+    2.715000000000  0.000000000000  2.715000000000
+    2.715000000000  2.715000000000  0.000000000000
+}
+
+COHP
+{
+    stru_file          STRU
+    atom_i_index      1
+    atom_j_index      2
+    atom_i_orbs       all
+    atom_j_orbs       all
+    method            COHP
+    spin              sum
+    e_range           -8.0 18.0
+    de                0.02
+    sigma             0.08
+    invert            1
+    shift_to_efermi   1
+    output_prefix     COHP
+    kpoint_mode       mp
+    mp_grid           4 4 4
+}

--- a/examples/Si2/pyatb/validate_cohp_against_standalone.py
+++ b/examples/Si2/pyatb/validate_cohp_against_standalone.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def load_spectrum(path):
+    data = np.loadtxt(path)
+    if data.ndim != 2 or data.shape[1] < 2:
+        raise ValueError("%s must contain at least two numeric columns" % path)
+    return data[:, 0], data[:, 1]
+
+
+def interpolate(reference_energy, reference_value, target_energy):
+    return np.interp(target_energy, reference_energy, reference_value)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare PyATB COHP spectrum with the standalone COHP script output."
+    )
+    parser.add_argument("pyatb", help="Path to Out/COHP/COHP.dat")
+    parser.add_argument("standalone", help="Path to standalone broadened COHP spectrum")
+    parser.add_argument("--rtol", type=float, default=1e-5)
+    parser.add_argument("--atol", type=float, default=1e-7)
+    args = parser.parse_args()
+
+    pyatb_energy, pyatb_value = load_spectrum(Path(args.pyatb))
+    standalone_energy, standalone_value = load_spectrum(Path(args.standalone))
+    standalone_on_grid = interpolate(standalone_energy, standalone_value, pyatb_energy)
+
+    diff = pyatb_value - standalone_on_grid
+    max_abs = float(np.max(np.abs(diff)))
+    rms = float(np.sqrt(np.mean(diff ** 2)))
+    passed = np.allclose(pyatb_value, standalone_on_grid, rtol=args.rtol, atol=args.atol)
+
+    print("points: %d" % pyatb_energy.size)
+    print("max_abs_diff: %.12g" % max_abs)
+    print("rms_diff: %.12g" % rms)
+    print("rtol: %.3g" % args.rtol)
+    print("atol: %.3g" % args.atol)
+    if not passed:
+        print("comparison: FAILED")
+        return 1
+    print("comparison: PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pyatb/fermi/__init__.py
+++ b/src/pyatb/fermi/__init__.py
@@ -4,6 +4,7 @@ from pyatb.fermi.bandunfolding_spin_texture import Bandunfolding_Spin_Texture
 from pyatb.fermi.fermi_energy import Fermi_Energy
 from pyatb.fermi.fermi_surface import Fermi_Surface
 from pyatb.fermi.find_nodes import Find_Nodes
+from pyatb.fermi.cohp import COHP
 from pyatb.fermi.jdos import JDOS
 from pyatb.fermi.pdos import PDOS
 from pyatb.fermi.spin_texture import Spin_Texture

--- a/src/pyatb/fermi/cohp.py
+++ b/src/pyatb/fermi/cohp.py
@@ -128,6 +128,11 @@ class COHP:
             return solver.get_Sk(kpoints)
         raise ValueError("COHP method must be COHP or COOP")
 
+    def _spin_degeneracy_factor(self, spin):
+        if self.nspin == 1 and spin.lower() == "sum":
+            return 2.0
+        return 1.0
+
     def calculate_cohp(self, fermi_energy, stru_file, atom_i_index, atom_j_index,
                        atom_i_orbs="all", atom_j_orbs="all", method="COHP", spin="sum",
                        e_range=None, de=0.05, sigma=0.15, invert=1, shift_to_efermi=1,
@@ -197,7 +202,7 @@ class COHP:
         spectrum = COMM.reduce(spectrum, root=0, op=op_sum)
 
         if RANK == 0:
-            spectrum = spectrum / self.__k_generator.total_kpoint_num
+            spectrum = spectrum / self.__k_generator.total_kpoint_num * self._spin_degeneracy_factor(spin)
             energy_grid = np.array([energy_min + i * de for i in range(e_num)], dtype=float)
             if shift_to_efermi:
                 output_energy = energy_grid - fermi_energy
@@ -285,12 +290,3 @@ plt.savefig(os.path.join(work_path, "cohp.pdf"))
 plt.close("all")
 """
             f.write(plot_script)
-
-        try:
-            import subprocess
-            import sys
-            script_directory = os.path.dirname(script_path)
-            subprocess.run([sys.executable, script_path], cwd=script_directory, capture_output=True, text=True)
-        except ImportError:
-            print("ImportError: COHP Plot requires matplotlib package!")
-            return None

--- a/src/pyatb/fermi/cohp.py
+++ b/src/pyatb/fermi/cohp.py
@@ -1,0 +1,296 @@
+from pyatb import RANK, COMM, SIZE, OUTPUT_PATH, RUNNING_LOG, timer
+from pyatb.kpt import kpoint_generator
+from pyatb.parallel import op_sum
+from pyatb.tb import tb
+from pyatb.tools.smearing import gauss
+from pyatb.fermi.orbital_selection import resolve_cohp_orbitals
+
+import json
+import os
+import shutil
+import numpy as np
+
+
+def cohp_values_one_k(matrix, eigenvalues, eigenvectors, atom_i_orbs, atom_j_orbs):
+    atom_i_orbs = np.asarray(atom_i_orbs, dtype=int)
+    atom_j_orbs = np.asarray(atom_j_orbs, dtype=int)
+    block = matrix[np.ix_(atom_i_orbs, atom_j_orbs)]
+    coeff_i = eigenvectors[atom_i_orbs, :]
+    coeff_j = eigenvectors[atom_j_orbs, :]
+    values = np.einsum("ib,ij,jb->b", coeff_i.conjugate(), block, coeff_j, optimize=True).real
+    return np.asarray(eigenvalues, dtype=float), values
+
+
+class COHP:
+    def __init__(
+        self,
+        tb: tb,
+        **kwarg
+    ):
+        self.__tb = tb
+        self.__max_kpoint_num = tb.max_kpoint_num
+        if tb.nspin != 2:
+            self.__tb_solver = (tb.tb_solver, )
+        else:
+            self.__tb_solver = (tb.tb_solver_up, tb.tb_solver_dn)
+        self.__k_generator = None
+        self.nspin = tb.nspin
+
+        output_path = os.path.join(OUTPUT_PATH, "COHP")
+        if RANK == 0:
+            if os.path.exists(output_path):
+                shutil.rmtree(output_path)
+            os.mkdir(output_path)
+
+        self.output_path = output_path
+
+        if RANK == 0:
+            with open(RUNNING_LOG, "a") as f:
+                f.write("\n")
+                f.write("\n------------------------------------------------------")
+                f.write("\n|                                                    |")
+                f.write("\n|                        COHP                        |")
+                f.write("\n|                                                    |")
+                f.write("\n------------------------------------------------------")
+                f.write("\n\n")
+
+    def set_k_generator(self, kpoint_mode=None, **kwarg):
+        if kpoint_mode is None:
+            kpoint_mode = "direct"
+            kwarg["kpoint_direct_coor"] = np.array([[0.0, 0.0, 0.0]], dtype=float)
+
+        if kpoint_mode == "mp":
+            self.__k_generator = kpoint_generator.mp_generator(
+                self.__max_kpoint_num,
+                kwarg.get("k_start", np.array([0.0, 0.0, 0.0], dtype=float)),
+                kwarg.get("k_vect1", np.array([1.0, 0.0, 0.0], dtype=float)),
+                kwarg.get("k_vect2", np.array([0.0, 1.0, 0.0], dtype=float)),
+                kwarg.get("k_vect3", np.array([0.0, 0.0, 1.0], dtype=float)),
+                kwarg["mp_grid"],
+            )
+        elif kpoint_mode == "line":
+            self.__k_generator = kpoint_generator.line_generator(
+                self.__max_kpoint_num,
+                kwarg["high_symmetry_kpoint"],
+                kwarg["kpoint_num_in_line"],
+            )
+        elif kpoint_mode == "direct":
+            self.__k_generator = kpoint_generator.array_generater(
+                self.__max_kpoint_num,
+                np.asarray(kwarg["kpoint_direct_coor"], dtype=float),
+            )
+        else:
+            raise ValueError("unknown COHP kpoint_mode: %s" % kpoint_mode)
+
+        if RANK == 0:
+            with open(RUNNING_LOG, "a") as f:
+                f.write("\nParameter setting of COHP kpoints : \n")
+                f.write(" >> kpoint_mode : %s\n" % kpoint_mode)
+
+    def _spin_indices(self, spin):
+        spin = spin.lower()
+        if self.nspin == 4:
+            raise ValueError("COHP currently supports nspin = 1 or 2; non-collinear nspin = 4 is not implemented")
+        if spin not in ("sum", "up", "down"):
+            raise ValueError("COHP spin must be one of: sum, up, down")
+        if self.nspin != 2:
+            if spin in ("up", "down"):
+                raise ValueError("COHP spin = up/down requires nspin = 2")
+            return [0]
+        if spin == "up":
+            return [0]
+        if spin == "down":
+            return [1]
+        return [0, 1]
+
+    def _accumulate_one_k(self, spectrum, matrix, eigenvalues, eigenvectors, atom_i_orbs,
+                          atom_j_orbs, energy_min, de, sigma, invert):
+        e_num = spectrum.shape[0]
+        energy_max = energy_min + de * e_num
+        interval = int(10 * sigma / de)
+        energies, values = cohp_values_one_k(matrix, eigenvalues, eigenvectors, atom_i_orbs, atom_j_orbs)
+        if invert:
+            values = -values
+        for energy, value in zip(energies, values):
+            if energy - energy_min <= 1e-8 or energy_max - energy <= 1e-8:
+                continue
+            index = int((energy - energy_min) / de)
+            start_index = max(0, index - interval)
+            end_index = min(e_num, index + interval + 1)
+            delta_E = energy_min + np.arange(start_index, end_index, dtype=float) * de - energy
+            spectrum[start_index:end_index] += value * gauss(sigma, delta_E)
+
+    def _matrix_for_method(self, solver, kpoints, method):
+        method = method.upper()
+        if method == "COHP":
+            return solver.get_Hk(kpoints)
+        if method == "COOP":
+            return solver.get_Sk(kpoints)
+        raise ValueError("COHP method must be COHP or COOP")
+
+    def calculate_cohp(self, fermi_energy, stru_file, atom_i_index, atom_j_index,
+                       atom_i_orbs="all", atom_j_orbs="all", method="COHP", spin="sum",
+                       e_range=None, de=0.05, sigma=0.15, invert=1, shift_to_efermi=1,
+                       output_prefix="COHP", **kwarg):
+        COMM.Barrier()
+        timer.start("cohp", "calculate COHP")
+
+        if e_range is None:
+            e_range = [fermi_energy - 10.0, fermi_energy + 10.0]
+        energy_min = float(e_range[0])
+        energy_max = float(e_range[1])
+        de = float(de)
+        sigma = float(sigma)
+        e_num = int((energy_max - energy_min) / de) + 1
+        spectrum = np.zeros(e_num, dtype=float)
+
+        if self.__k_generator is None:
+            self.set_k_generator(**kwarg)
+
+        selection = resolve_cohp_orbitals(
+            stru_file=stru_file,
+            atom_i_index=atom_i_index,
+            atom_j_index=atom_j_index,
+            atom_i_orbs=atom_i_orbs,
+            atom_j_orbs=atom_j_orbs,
+            input_file=kwarg.get("input_file"),
+            orbital_dir=kwarg.get("orbital_dir"),
+        )
+        spin_indices = self._spin_indices(spin)
+
+        if RANK == 0:
+            with open(RUNNING_LOG, "a") as f:
+                f.write("\nEnter the COHP calculation module ==> \n")
+                f.write(" >> atom_i_index : %d\n" % atom_i_index)
+                f.write(" >> atom_j_index : %d\n" % atom_j_index)
+                f.write(" >> atom_i_orbs  : %s\n" % selection.atom_i_orbitals)
+                f.write(" >> atom_j_orbs  : %s\n" % selection.atom_j_orbitals)
+                f.write(" >> method       : %s\n" % method.upper())
+                f.write(" >> spin         : %s\n" % spin)
+                f.write(" >> e_range      : %.6f %.6f\n" % (energy_min, energy_max))
+                f.write(" >> de           : %.6f\n" % de)
+                f.write(" >> sigma        : %.6f\n" % sigma)
+
+        for ik in self.__k_generator:
+            ik_process = kpoint_generator.kpoints_in_different_process(SIZE, RANK, ik)
+            kpoint_num = ik_process.k_direct_coor_local.shape[0]
+            if not kpoint_num:
+                continue
+            for ispin in spin_indices:
+                solver = self.__tb_solver[ispin]
+                eigenvectors, eigenvalues = solver.diago_H(ik_process.k_direct_coor_local)
+                matrices = self._matrix_for_method(solver, ik_process.k_direct_coor_local, method)
+                for single_k in range(kpoint_num):
+                    self._accumulate_one_k(
+                        spectrum,
+                        matrices[single_k],
+                        eigenvalues[single_k],
+                        eigenvectors[single_k],
+                        selection.atom_i_orbitals,
+                        selection.atom_j_orbitals,
+                        energy_min,
+                        de,
+                        sigma,
+                        bool(invert),
+                    )
+
+        spectrum = COMM.reduce(spectrum, root=0, op=op_sum)
+
+        if RANK == 0:
+            spectrum = spectrum / self.__k_generator.total_kpoint_num
+            energy_grid = np.array([energy_min + i * de for i in range(e_num)], dtype=float)
+            if shift_to_efermi:
+                output_energy = energy_grid - fermi_energy
+            else:
+                output_energy = energy_grid
+            self.print_data(
+                output_prefix,
+                output_energy,
+                spectrum,
+                selection,
+                method,
+                spin,
+                fermi_energy,
+                bool(shift_to_efermi),
+            )
+
+        COMM.Barrier()
+        timer.end("cohp", "calculate COHP")
+
+    def print_data(self, output_prefix, energy, spectrum, selection, method, spin,
+                   fermi_energy, shifted):
+        data_filename = "%s.dat" % output_prefix
+        meta_filename = "%s.meta.json" % output_prefix
+        np.savetxt(
+            os.path.join(self.output_path, data_filename),
+            np.c_[energy, spectrum],
+            fmt="%0.8f",
+            header="energy_eV %s" % method.upper(),
+        )
+
+        metadata = {
+            "method": method.upper(),
+            "spin": spin,
+            "fermi_energy_eV": float(fermi_energy),
+            "energy_shifted_to_efermi": shifted,
+            "files": {
+                "spectrum": data_filename,
+            },
+            "atom_i_orbitals": selection.atom_i_orbitals,
+            "atom_j_orbitals": selection.atom_j_orbitals,
+            "total_orbitals": selection.orbital_map.total_orbitals,
+            "atoms": [
+                {
+                    "index": atom.index,
+                    "element": atom.element,
+                    "orbital_file": atom.orbital_file,
+                    "shell_counts": atom.shell_counts,
+                    "start": atom.start,
+                    "stop": atom.stop,
+                }
+                for atom in selection.orbital_map.atoms
+            ],
+        }
+        with open(os.path.join(self.output_path, meta_filename), "w") as file_obj:
+            json.dump(metadata, file_obj, indent=4)
+
+    def print_plot_script(self):
+        script_path = os.path.join(self.output_path, "plot_cohp.py")
+        with open(script_path, "w") as f:
+            plot_script = """
+import glob
+import json
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+
+work_path = os.getcwd()
+meta_files = sorted(glob.glob(os.path.join(work_path, "*.meta.json")))
+if not meta_files:
+    raise FileNotFoundError("no COHP metadata file found")
+with open(meta_files[0]) as file_obj:
+    metadata = json.load(file_obj)
+
+data = np.loadtxt(os.path.join(work_path, metadata["files"]["spectrum"]))
+energy, cohp = data[:, 0], data[:, 1]
+
+fig, ax = plt.subplots(1, 1, tight_layout=True)
+ax.axvline(0.0, color="0.7", linewidth=0.8)
+ax.axhline(0.0, color="0.7", linewidth=0.8)
+ax.plot(cohp, energy)
+ax.set_xlabel(metadata["method"])
+ax.set_ylabel(r"$E-E_F$ (eV)" if metadata["energy_shifted_to_efermi"] else "Energy (eV)")
+ax.set_title(metadata["method"])
+plt.savefig(os.path.join(work_path, "cohp.pdf"))
+plt.close("all")
+"""
+            f.write(plot_script)
+
+        try:
+            import subprocess
+            import sys
+            script_directory = os.path.dirname(script_path)
+            subprocess.run([sys.executable, script_path], cwd=script_directory, capture_output=True, text=True)
+        except ImportError:
+            print("ImportError: COHP Plot requires matplotlib package!")
+            return None

--- a/src/pyatb/fermi/orbital_selection.py
+++ b/src/pyatb/fermi/orbital_selection.py
@@ -182,7 +182,7 @@ def _shell_ranges(shell_counts, start):
 
 
 def build_orbital_map(stru_file, input_file=None, orbital_dir=None):
-    if orbital_dir is None:
+    if not orbital_dir:
         orbital_dir = parse_input_orbital_dir(input_file) if input_file else None
 
     atom_meta, orbital_files = parse_stru_metadata(stru_file)

--- a/src/pyatb/fermi/orbital_selection.py
+++ b/src/pyatb/fermi/orbital_selection.py
@@ -1,0 +1,288 @@
+from dataclasses import dataclass
+import os
+import re
+
+
+L_MULTIPLICITY = {
+    "s": 1,
+    "p": 3,
+    "d": 5,
+    "f": 7,
+    "g": 9,
+}
+SHELL_ORDER = ["s", "p", "d", "f", "g"]
+
+
+@dataclass(frozen=True)
+class OrbitalAtom:
+    index: int
+    element: str
+    orbital_file: str
+    shell_counts: dict
+    start: int
+    stop: int
+
+
+@dataclass(frozen=True)
+class OrbitalMap:
+    atoms: tuple
+    total_orbitals: int
+
+
+@dataclass(frozen=True)
+class OrbitalSelection:
+    atom_i_orbitals: list
+    atom_j_orbitals: list
+    orbital_map: OrbitalMap
+
+
+@dataclass(frozen=True)
+class ResolvedOrbitals:
+    indices: list
+
+
+def _strip_comment(line):
+    return re.sub(r"#.*$", "", line).strip()
+
+
+def _section_lines(lines, section_name):
+    for index, line in enumerate(lines):
+        if _strip_comment(line).upper() == section_name:
+            section = []
+            for next_line in lines[index + 1:]:
+                clean = _strip_comment(next_line)
+                if clean and re.match(r"^[A-Z_]+$", clean):
+                    break
+                if clean:
+                    section.append(clean)
+            return section
+    return []
+
+
+def parse_input_orbital_dir(input_file):
+    if not input_file:
+        return ""
+    input_dir = os.path.dirname(os.path.abspath(input_file))
+    with open(input_file) as file_obj:
+        tokens = []
+        for line in file_obj:
+            tokens.extend(_strip_comment(line).split())
+
+    for index, token in enumerate(tokens):
+        if token == "orbital_dir" and index + 1 < len(tokens):
+            orbital_dir = tokens[index + 1]
+            if os.path.isabs(orbital_dir):
+                return orbital_dir
+            return os.path.abspath(os.path.join(input_dir, orbital_dir))
+    return input_dir
+
+
+def parse_stru_metadata(stru_file):
+    with open(stru_file) as file_obj:
+        lines = file_obj.readlines()
+
+    species_lines = _section_lines(lines, "ATOMIC_SPECIES")
+    numerical_lines = _section_lines(lines, "NUMERICAL_ORBITAL")
+    position_lines = _section_lines(lines, "ATOMIC_POSITIONS")
+
+    elements = []
+    for line in species_lines:
+        tokens = line.split()
+        if len(tokens) < 3:
+            continue
+        elements.append(tokens[0])
+
+    orbital_files = {}
+    for element, line in zip(elements, numerical_lines):
+        orbital_files[element] = line.split()[0]
+
+    atoms = []
+    index = 1
+    current_element = None
+    expected_count = None
+    skipped_header = False
+    for line in position_lines[1:]:
+        tokens = line.split()
+        if not tokens:
+            continue
+        if tokens[0] in elements:
+            current_element = tokens[0]
+            expected_count = None
+            skipped_header = False
+            continue
+        if current_element is None:
+            continue
+        if not skipped_header:
+            skipped_header = True
+            continue
+        if expected_count is None:
+            expected_count = int(float(tokens[0]))
+            continue
+        if expected_count <= 0:
+            continue
+        atoms.append({"index": index, "element": current_element})
+        index += 1
+        expected_count -= 1
+
+    return atoms, orbital_files
+
+
+def _shell_counts_from_orbital_file(orbital_path):
+    counts = {}
+    if not orbital_path or not os.path.exists(orbital_path):
+        return counts
+    with open(orbital_path, errors="ignore") as file_obj:
+        for line in file_obj:
+            match = re.match(r"\s*Number of (\w)-orbital\s*-->\s*(\d+)", line)
+            if match:
+                shell = match.group(1).lower()
+                if shell in L_MULTIPLICITY:
+                    counts[shell] = int(match.group(2))
+    return counts
+
+
+def _shell_counts_from_filename(filename):
+    basename = os.path.basename(filename)
+    counts = {}
+    for count, shell in re.findall(r"(\d+)([spdfg])", basename):
+        counts[shell] = int(count)
+    return counts
+
+
+def parse_orbital_shells(orbital_path):
+    counts = _shell_counts_from_orbital_file(orbital_path)
+    if counts:
+        return counts
+    return _shell_counts_from_filename(orbital_path)
+
+
+def _resolve_orbital_path(stru_file, orbital_dir, orbital_file):
+    candidates = []
+    if os.path.isabs(orbital_file):
+        candidates.append(orbital_file)
+    if orbital_dir:
+        candidates.append(os.path.join(orbital_dir, orbital_file))
+    candidates.append(os.path.join(os.path.dirname(os.path.abspath(stru_file)), orbital_file))
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return candidates[0]
+
+
+def _shell_ranges(shell_counts, start):
+    ranges = {}
+    cursor = start
+    for shell in SHELL_ORDER:
+        count = shell_counts.get(shell, 0)
+        shell_size = count * L_MULTIPLICITY[shell]
+        if shell_size:
+            ranges[shell] = list(range(cursor, cursor + shell_size))
+        cursor += shell_size
+    return ranges, cursor
+
+
+def build_orbital_map(stru_file, input_file=None, orbital_dir=None):
+    if orbital_dir is None:
+        orbital_dir = parse_input_orbital_dir(input_file) if input_file else None
+
+    atom_meta, orbital_files = parse_stru_metadata(stru_file)
+    atoms = []
+    cursor = 0
+    for atom in atom_meta:
+        orbital_file = orbital_files.get(atom["element"])
+        if orbital_file is None:
+            raise ValueError("missing numerical orbital file for element %s" % atom["element"])
+        orbital_path = _resolve_orbital_path(stru_file, orbital_dir, orbital_file)
+        shell_counts = parse_orbital_shells(orbital_path)
+        if not shell_counts:
+            raise ValueError("cannot determine orbital shells from %s" % orbital_path)
+        _, stop = _shell_ranges(shell_counts, cursor)
+        atoms.append(
+            OrbitalAtom(
+                index=atom["index"],
+                element=atom["element"],
+                orbital_file=orbital_path,
+                shell_counts=shell_counts,
+                start=cursor,
+                stop=stop,
+            )
+        )
+        cursor = stop
+    return OrbitalMap(atoms=tuple(atoms), total_orbitals=cursor)
+
+
+def parse_global_orbital_indices(selector):
+    if isinstance(selector, (list, tuple)):
+        return [int(value) for value in selector]
+    values = []
+    for token in re.split(r"[\s,]+", str(selector).strip()):
+        if token:
+            values.append(int(token))
+    return values
+
+
+def _selector_tokens(selector):
+    if selector is None:
+        return ["all"]
+    if isinstance(selector, (list, tuple)):
+        raw_tokens = selector
+    else:
+        raw_tokens = re.split(r"[\s,]+", str(selector).strip())
+    return [token.lower() for token in raw_tokens if token]
+
+
+def _selector_shell(token):
+    if token in L_MULTIPLICITY:
+        return token
+    match = re.match(r"^\d+([spdfg])$", token)
+    if match:
+        return match.group(1)
+    return None
+
+
+def resolve_atom_orbitals(orbital_map, atom_index, selector="all"):
+    atom = None
+    for candidate in orbital_map.atoms:
+        if candidate.index == int(atom_index):
+            atom = candidate
+            break
+    if atom is None:
+        raise ValueError("atom index %s is not present in STRU" % atom_index)
+
+    if str(selector).strip().lower() in ("all", "*"):
+        return ResolvedOrbitals(list(range(atom.start, atom.stop)))
+
+    shell_ranges, _ = _shell_ranges(atom.shell_counts, atom.start)
+    orbitals = []
+    for token in _selector_tokens(selector):
+        if token in ("all", "*"):
+            orbitals.extend(range(atom.start, atom.stop))
+            continue
+        shell = _selector_shell(token)
+        if shell is not None:
+            if shell not in shell_ranges:
+                raise ValueError("atom %s has no %s orbitals" % (atom_index, token))
+            orbitals.extend(shell_ranges[shell])
+            continue
+        orbitals.append(int(token))
+
+    result = []
+    seen = set()
+    for orbital in orbitals:
+        if orbital in seen:
+            continue
+        if orbital < 0 or orbital >= orbital_map.total_orbitals:
+            raise ValueError("orbital index %s is out of range" % orbital)
+        seen.add(orbital)
+        result.append(orbital)
+    return ResolvedOrbitals(result)
+
+
+def resolve_cohp_orbitals(stru_file, atom_i_index, atom_j_index, atom_i_orbs="all",
+                          atom_j_orbs="all", input_file=None, orbital_dir=None):
+    orbital_map = build_orbital_map(stru_file, input_file=input_file, orbital_dir=orbital_dir)
+    return OrbitalSelection(
+        atom_i_orbitals=resolve_atom_orbitals(orbital_map, atom_i_index, atom_i_orbs).indices,
+        atom_j_orbitals=resolve_atom_orbitals(orbital_map, atom_j_index, atom_j_orbs).indices,
+        orbital_map=orbital_map,
+    )

--- a/src/pyatb/io/default_input.py
+++ b/src/pyatb/io/default_input.py
@@ -212,6 +212,8 @@ INPUT = {
         'invert'                      : [int, 1, 1],
         'shift_to_efermi'             : [int, 1, 1],
         'output_prefix'               : [str, 1, 'COHP'],
+        'input_file'                  : [str, 1, ''],
+        'orbital_dir'                 : [str, 1, ''],
         'kpoint_mode'                 : [str, 1, None]
     },
 

--- a/src/pyatb/io/default_input.py
+++ b/src/pyatb/io/default_input.py
@@ -13,6 +13,7 @@ function_switch = {
     'BANDUNFOLDING'           : False,
     'BANDUNFOLDING_SPIN_TEXTURE'           : False,
     'FAT_BAND'                : False,
+    'COHP'                    : False,
     'FERMI_ENERGY'            : False,
     'FERMI_SURFACE'           : False,
     'FIND_NODES'              : False,
@@ -193,6 +194,24 @@ INPUT = {
     {
         'band_range'                  : [int, 2, None],
         'stru_file'                   : [str, 1, None],
+        'kpoint_mode'                 : [str, 1, None]
+    },
+
+    'COHP' :
+    {
+        'stru_file'                   : [str, 1, None],
+        'atom_i_index'                : [int, 1, -1],
+        'atom_j_index'                : [int, 1, -1],
+        'atom_i_orbs'                 : [str, -1, 'all'],
+        'atom_j_orbs'                 : [str, -1, 'all'],
+        'method'                      : [str, 1, 'COHP'],
+        'spin'                        : [str, 1, 'sum'],
+        'e_range'                     : [float, 2, None],
+        'de'                          : [float, 1, 0.05],
+        'sigma'                       : [float, 1, 0.15],
+        'invert'                      : [int, 1, 1],
+        'shift_to_efermi'             : [int, 1, 1],
+        'output_prefix'               : [str, 1, 'COHP'],
         'kpoint_mode'                 : [str, 1, None]
     },
 

--- a/src/pyatb/io/input.py
+++ b/src/pyatb/io/input.py
@@ -70,7 +70,7 @@ def get_block_data(block_name: str, file_block: dict):
         else:
             raise ValueError(block_name + ' is empty!')
 
-def get_general_parameter(parameter_name: str, default: None, data: None):
+def get_general_parameter(parameter_name: str, default: None, data: None, parameter_names=None):
     """ 
     Extract information with the parameter_name from data.
 
@@ -83,6 +83,18 @@ def get_general_parameter(parameter_name: str, default: None, data: None):
         if value == parameter_name:
             if default[1] == 1:
                 return default[0](data[index+1])
+            elif default[1] == -1:
+                values = []
+                known = set(parameter_names or [])
+                for token in data[index + 1:]:
+                    if token in known:
+                        break
+                    values.append(default[0](token))
+                if not values:
+                    if default[2] is None:
+                        raise KeyError('key parameter missing: ' + parameter_name)
+                    return default[2]
+                return ','.join(values)
             else:
                 tem = []
                 for i_size in range(default[1]):
@@ -132,7 +144,9 @@ def update_INPUT(input_filename):
             # search optional parameters
             for i in parameter_options.keys():
                 if i in block_parameters.keys():
-                    block_parameters[i][-1] = get_general_parameter(i, block_parameters[i], block_data)
+                    block_parameters[i][-1] = get_general_parameter(
+                        i, block_parameters[i], block_data, block_parameters.keys()
+                    )
                     option = block_parameters[i][-1]
                     option_dict = copy.deepcopy(parameter_options[i][option])
                     block_parameters.update(option_dict)
@@ -140,7 +154,9 @@ def update_INPUT(input_filename):
             # search general parameters
             for i in block_parameters.keys():
                 if i not in parameter_multigroups and i not in parameter_dependence:
-                    block_parameters[i][-1] = get_general_parameter(i, block_parameters[i], block_data)
+                    block_parameters[i][-1] = get_general_parameter(
+                        i, block_parameters[i], block_data, block_parameters.keys()
+                    )
 
             # search multigroups parameters
             for i in parameter_multigroups.keys():
@@ -157,7 +173,9 @@ def update_INPUT(input_filename):
                         tem_list.append(block_parameters[tem_value][-1])
                     tem_fun = parameter_dependence[i][1]
                     block_parameters[i] = tem_fun(*tem_list)
-                    block_parameters[i][-1] = get_general_parameter(i, block_parameters[i], block_data)
+                    block_parameters[i][-1] = get_general_parameter(
+                        i, block_parameters[i], block_data, block_parameters.keys()
+                    )
                     
 
     # rearrange the parameters in the dictionary INPUT

--- a/src/pyatb/main.py
+++ b/src/pyatb/main.py
@@ -10,6 +10,14 @@ from pyatb.berry import *
 from pyatb.transport import *
 import os
 
+
+def _cohp_parameters_with_default_input(cohp_parameters, input_path):
+    parameters = dict(cohp_parameters)
+    if not parameters.get("input_file"):
+        parameters["input_file"] = os.path.join(input_path, "Input")
+    return parameters
+
+
 def main():
     # get user INPUT
     INPUT, function_switch, bool_need_rR = read_input(os.path.join(INPUT_PATH, 'Input'))
@@ -126,7 +134,7 @@ def main():
             cal_FAT.print_plot_script(fermi_energy)
 
     if function_switch['COHP']:
-        cohp_parameters = INPUT['COHP']
+        cohp_parameters = _cohp_parameters_with_default_input(INPUT['COHP'], INPUT_PATH)
         cal_COHP = COHP(m_tb)
         fermi_energy = input_parameters['fermi_energy']
         cal_COHP.calculate_cohp(fermi_energy=fermi_energy, **cohp_parameters)

--- a/src/pyatb/main.py
+++ b/src/pyatb/main.py
@@ -125,6 +125,14 @@ def main():
             fermi_energy = input_parameters['fermi_energy']
             cal_FAT.print_plot_script(fermi_energy)
 
+    if function_switch['COHP']:
+        cohp_parameters = INPUT['COHP']
+        cal_COHP = COHP(m_tb)
+        fermi_energy = input_parameters['fermi_energy']
+        cal_COHP.calculate_cohp(fermi_energy=fermi_energy, **cohp_parameters)
+        if RANK == 0:
+            cal_COHP.print_plot_script()
+
     if function_switch['FERMI_SURFACE']:
         fermi_surface_parameters = INPUT['FERMI_SURFACE']
         cal_FS = Fermi_Surface(m_tb)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+if "mpi4py" not in sys.modules:
+    class _DummyComm:
+        def Get_size(self):
+            return 1
+
+        def Get_rank(self):
+            return 0
+
+        def Barrier(self):
+            return None
+
+        def reduce(self, value, root=0, op=None):
+            return value
+
+    class _DummyOp:
+        @staticmethod
+        def Create(func, commute=False):
+            return func
+
+    dummy_mpi = types.SimpleNamespace(COMM_WORLD=_DummyComm(), Op=_DummyOp, SUM="sum")
+    sys.modules["mpi4py"] = types.SimpleNamespace(MPI=dummy_mpi)
+
+
+if "pyatb.interface_python" not in sys.modules:
+    class _DummyInterfacePython:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    sys.modules["pyatb.interface_python"] = types.SimpleNamespace(
+        interface_python=_DummyInterfacePython
+    )

--- a/tests/test_cohp_input.py
+++ b/tests/test_cohp_input.py
@@ -1,0 +1,23 @@
+from pyatb.io.default_input import INPUT, function_switch, need_rR_matrix
+from pyatb.io.input import get_general_parameter
+
+
+def test_cohp_input_block_is_registered_without_rr_requirement():
+    assert "COHP" in function_switch
+    assert "COHP" in INPUT
+    assert "COHP" not in need_rR_matrix
+
+    cohp = INPUT["COHP"]
+    assert cohp["stru_file"][-1] is None
+    assert cohp["method"][-1] == "COHP"
+    assert cohp["spin"][-1] == "sum"
+    assert cohp["kpoint_mode"][-1] is None
+
+
+def test_variable_length_orbital_selector_stops_at_next_known_parameter():
+    data = ["atom_i_orbs", "2s", "2p", "atom_j_orbs", "all", "de", "0.02"]
+    known = {"atom_i_orbs", "atom_j_orbs", "de"}
+
+    assert get_general_parameter("atom_i_orbs", [str, -1, "all"], data, known) == "2s,2p"
+    assert get_general_parameter("atom_j_orbs", [str, -1, "all"], data, known) == "all"
+    assert get_general_parameter("de", [float, 1, 0.05], data, known) == 0.02

--- a/tests/test_cohp_input.py
+++ b/tests/test_cohp_input.py
@@ -1,5 +1,6 @@
 from pyatb.io.default_input import INPUT, function_switch, need_rR_matrix
 from pyatb.io.input import get_general_parameter
+from pyatb.main import _cohp_parameters_with_default_input
 
 
 def test_cohp_input_block_is_registered_without_rr_requirement():
@@ -11,7 +12,26 @@ def test_cohp_input_block_is_registered_without_rr_requirement():
     assert cohp["stru_file"][-1] is None
     assert cohp["method"][-1] == "COHP"
     assert cohp["spin"][-1] == "sum"
+    assert cohp["input_file"][-1] == ""
+    assert cohp["orbital_dir"][-1] == ""
     assert cohp["kpoint_mode"][-1] is None
+
+
+def test_cohp_main_defaults_input_file_to_input_path(tmp_path):
+    parameters = {"stru_file": "STRU", "input_file": ""}
+
+    result = _cohp_parameters_with_default_input(parameters, str(tmp_path))
+
+    assert result == {"stru_file": "STRU", "input_file": str(tmp_path / "Input")}
+    assert parameters == {"stru_file": "STRU", "input_file": ""}
+
+
+def test_cohp_main_keeps_explicit_input_file(tmp_path):
+    parameters = {"stru_file": "STRU", "input_file": "custom/INPUT"}
+
+    result = _cohp_parameters_with_default_input(parameters, str(tmp_path))
+
+    assert result["input_file"] == "custom/INPUT"
 
 
 def test_variable_length_orbital_selector_stops_at_next_known_parameter():

--- a/tests/test_cohp_kernel.py
+++ b/tests/test_cohp_kernel.py
@@ -1,6 +1,9 @@
 import numpy as np
+import inspect
+import types
 
-from pyatb.fermi.cohp import cohp_values_one_k
+import pyatb.fermi.cohp as cohp_module
+from pyatb.fermi.cohp import COHP, cohp_values_one_k
 
 
 def test_cohp_values_one_k_matches_standalone_formula():
@@ -33,3 +36,72 @@ def test_cohp_values_one_k_matches_standalone_formula():
 
     np.testing.assert_allclose(energies, eigenvalues)
     np.testing.assert_allclose(values, np.array(expected))
+
+
+def test_print_plot_script_only_writes_script(tmp_path):
+    cohp = COHP.__new__(COHP)
+    cohp.output_path = str(tmp_path)
+
+    cohp.print_plot_script()
+
+    assert (tmp_path / "plot_cohp.py").is_file()
+    assert not (tmp_path / "cohp.pdf").exists()
+    assert "subprocess.run" not in inspect.getsource(COHP.print_plot_script)
+
+
+class _SingleKGenerator:
+    total_kpoint_num = 1
+
+    def __iter__(self):
+        return iter([np.array([[0.0, 0.0, 0.0]], dtype=float)])
+
+
+class _UnitSolver:
+    def diago_H(self, kpoints):
+        eigenvectors = np.ones((kpoints.shape[0], 1, 1), dtype=np.complex128)
+        eigenvalues = np.zeros((kpoints.shape[0], 1), dtype=float)
+        return eigenvectors, eigenvalues
+
+    def get_Hk(self, kpoints):
+        return np.ones((kpoints.shape[0], 1, 1), dtype=np.complex128)
+
+
+def _cohp_with_fake_solver(nspin):
+    cohp = COHP.__new__(COHP)
+    cohp.nspin = nspin
+    cohp._COHP__k_generator = _SingleKGenerator()
+    solver = _UnitSolver()
+    cohp._COHP__tb_solver = (solver, solver) if nspin == 2 else (solver,)
+    return cohp
+
+
+def _calculate_fake_spectrum(cohp, monkeypatch):
+    captured = {}
+    selection = types.SimpleNamespace(
+        atom_i_orbitals=[0],
+        atom_j_orbitals=[0],
+        orbital_map=types.SimpleNamespace(total_orbitals=1, atoms=[]),
+    )
+    monkeypatch.setattr(cohp_module, "resolve_cohp_orbitals", lambda **kwargs: selection)
+    monkeypatch.setattr(COHP, "print_data", lambda self, output_prefix, energy, spectrum, *args: captured.update(spectrum=spectrum.copy()))
+
+    cohp.calculate_cohp(
+        fermi_energy=0.0,
+        stru_file="STRU",
+        atom_i_index=1,
+        atom_j_index=1,
+        method="COHP",
+        spin="sum",
+        e_range=[-1.0, 1.0],
+        de=0.5,
+        sigma=0.1,
+        invert=0,
+    )
+    return captured["spectrum"]
+
+
+def test_nspin1_sum_cohp_includes_spin_degeneracy(monkeypatch):
+    nspin1_spectrum = _calculate_fake_spectrum(_cohp_with_fake_solver(nspin=1), monkeypatch)
+    nspin2_sum_spectrum = _calculate_fake_spectrum(_cohp_with_fake_solver(nspin=2), monkeypatch)
+
+    np.testing.assert_allclose(nspin1_spectrum, nspin2_sum_spectrum)

--- a/tests/test_cohp_kernel.py
+++ b/tests/test_cohp_kernel.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from pyatb.fermi.cohp import cohp_values_one_k
+
+
+def test_cohp_values_one_k_matches_standalone_formula():
+    matrix = np.array(
+        [
+            [1.0, 2.0 + 0.5j, 0.0],
+            [2.0 - 0.5j, 3.0, 4.0],
+            [0.0, 4.0, 5.0],
+        ],
+        dtype=np.complex128,
+    )
+    eigenvalues = np.array([-1.0, 0.5], dtype=float)
+    eigenvectors = np.array(
+        [
+            [1.0 + 0.0j, 0.0 + 1.0j],
+            [0.5 + 0.5j, 1.0 + 0.0j],
+            [0.25 + 0.0j, 0.5 - 0.25j],
+        ],
+        dtype=np.complex128,
+    )
+
+    energies, values = cohp_values_one_k(matrix, eigenvalues, eigenvectors, [0, 1], [2])
+
+    expected = []
+    for ib in range(eigenvectors.shape[1]):
+        total = 0.0
+        for iorb in [0, 1]:
+            total += (eigenvectors[iorb, ib].conjugate() * matrix[iorb, 2] * eigenvectors[2, ib]).real
+        expected.append(total)
+
+    np.testing.assert_allclose(energies, eigenvalues)
+    np.testing.assert_allclose(values, np.array(expected))

--- a/tests/test_orbital_selection.py
+++ b/tests/test_orbital_selection.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from pyatb.fermi.orbital_selection import (
+    build_orbital_map,
+    parse_global_orbital_indices,
+    resolve_atom_orbitals,
+)
+
+
+def test_resolves_abacus_atom_shells_to_global_nao_indices():
+    root = Path(__file__).resolve().parents[1]
+    stru = root / "examples" / "Si2" / "pyatb" / "STRU"
+
+    orbital_map = build_orbital_map(stru)
+
+    assert orbital_map.total_orbitals == 26
+    assert resolve_atom_orbitals(orbital_map, 1, "all").indices == list(range(0, 13))
+    assert resolve_atom_orbitals(orbital_map, 2, "all").indices == list(range(13, 26))
+    assert resolve_atom_orbitals(orbital_map, 1, "2s").indices == [0, 1]
+    assert resolve_atom_orbitals(orbital_map, 1, "2p").indices == list(range(2, 8))
+    assert resolve_atom_orbitals(orbital_map, 1, "1d").indices == list(range(8, 13))
+
+
+def test_parse_global_orbital_indices():
+    assert parse_global_orbital_indices("0, 2,5") == [0, 2, 5]

--- a/tests/test_orbital_selection.py
+++ b/tests/test_orbital_selection.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 
 from pyatb.fermi.orbital_selection import (
     build_orbital_map,
@@ -23,3 +24,20 @@ def test_resolves_abacus_atom_shells_to_global_nao_indices():
 
 def test_parse_global_orbital_indices():
     assert parse_global_orbital_indices("0, 2,5") == [0, 2, 5]
+
+
+def test_build_orbital_map_uses_relative_abacus_orbital_dir(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    source_dir = root / "examples" / "Si2" / "pyatb"
+    stru = tmp_path / "STRU"
+    orbital_dir = tmp_path / "basis"
+    orbital_dir.mkdir()
+    shutil.copy(source_dir / "STRU", stru)
+    shutil.copy(source_dir / "Si_lda_8.0au_50Ry_2s2p1d", orbital_dir / "Si_lda_8.0au_50Ry_2s2p1d")
+    input_file = tmp_path / "Input"
+    input_file.write_text("INPUT_PARAMETERS\n{\n    orbital_dir basis\n}\n")
+
+    orbital_map = build_orbital_map(stru, input_file=input_file)
+
+    assert orbital_map.total_orbitals == 26
+    assert all(str(atom.orbital_file).startswith(str(orbital_dir)) for atom in orbital_map.atoms)


### PR DESCRIPTION
## Summary

This branch adds a `COHP` Fermi-function module to PyATB for atom-pair
COHP/COOP spectra based on the existing tight-binding solvers and ABACUS NAO
metadata.

Relative to `origin/main`, the branch is a four-commit series:

- core COHP workflow and input-system integration
- user documentation, an Si2 example input, and a standalone-comparison helper
- focused parsing/kernel tests
- follow-up fixes for input fallback, `nspin = 1` normalization, plotting
  behavior, and documentation completeness

Included in this PR:

- `pyatb.fermi.cohp.COHP` and the one-k-point contraction kernel.
- ABACUS `STRU` and numerical-orbital helpers for mapping atom/orbital
  selectors to PyATB global NAO indices.
- A new `COHP` input block wired into PyATB input parsing and `main.py`
  dispatch.
- User documentation, an Si2 example input, a standalone validation helper, and
  focused tests.

## Implementation Notes

The implementation follows the existing PyATB Fermi-module pattern:

- `COHP` is implemented under `pyatb.fermi` and receives the existing `tb`
  object.
- It reuses the configured `tb_solver` instances and does not add a separate
  Hamiltonian reader.
- It uses PyATB's `kpoint_generator`, MPI rank splitting, `COMM.reduce`,
  timing hooks, `RUNNING_LOG`, and `OUTPUT_PATH`.
- Output is written under `Out/COHP`; `plot_cohp.py` is generated but not
  executed automatically.

For `method = COHP`, the module contracts `H(k)`; for `method = COOP`, it
contracts `S(k)`. Spectra are broadened with PyATB's existing Gaussian
smearing helper. For `nspin = 1` and `spin = sum`, the output includes the
spin-degeneracy factor consistent with the current PyATB DOS conventions.

This PR does not introduce an independent ABACUS `OUT.ABACUS` cache reader and
keeps the implementation inside PyATB's existing solver/input architecture.

## User Input

```text
COHP
{
    stru_file          STRU
    atom_i_index       1
    atom_j_index       2
    atom_i_orbs        all
    atom_j_orbs        2p
    method             COHP
    spin               sum
    e_range            -8.0 8.0
    de                 0.02
    sigma              0.08
    invert             1
    shift_to_efermi    1
    output_prefix      COHP
    input_file         Input
    orbital_dir        basis
    kpoint_mode        mp
    mp_grid            8 8 8
}
```

Selector and path behavior:

- `atom_i_orbs` and `atom_j_orbs` accept `all`, `s/p/d/f/g`, shell-like forms
  such as `2p`, and comma/space separated global orbital indices.
- Numeric prefixes in selectors are currently angular-momentum aliases only:
  `2p` is treated the same as `p`; it does not select a distinct radial shell.
- Atom indices are 1-based and follow the atom order in the ABACUS `STRU`
  file.
- `orbital_dir` has highest priority; otherwise COHP tries to read
  `orbital_dir` from `input_file`.
- If `input_file` is omitted in the `COHP` block, PyATB passes the running
  `Input` path automatically.
- If neither `orbital_dir` nor `input_file` provides a directory, the `STRU`
  directory is used as the fallback search location for numerical orbital
  files.

## Output

The module writes results to `Out/COHP`:

- `<output_prefix>.dat`: two-column spectrum file (`energy_eV`, `COHP` or
  `COOP`).
- `<output_prefix>.meta.json`: selected atoms, global orbital indices, shell
  counts, and output file metadata.
- `plot_cohp.py`: optional plotting helper that can be run manually to produce
  `cohp.pdf`.

With `shift_to_efermi = 1`, the energy axis is written as `E - E_F`.

## Validation

Checks run in the `pyatb-cohp` conda environment with ABACUS LTS 3.10.1's
OpenMPI module loaded:

- From `tools/pyatb`:
  `python -m pytest tests/test_cohp_input.py tests/test_cohp_kernel.py tests/test_orbital_selection.py -q`
  - Current result on this branch: `10 passed`
- From `tools/pyatb`:
  `python -m py_compile src/pyatb/main.py src/pyatb/io/default_input.py src/pyatb/io/input.py src/pyatb/fermi/cohp.py src/pyatb/fermi/orbital_selection.py`
- Import check from `tools/pyatb`, with `PYTHONPATH=src` and `mpi4py`
  available:
  `PYTHONPATH=src python -c "from pyatb.fermi import COHP; from pyatb.fermi.cohp import cohp_values_one_k; from pyatb.fermi.orbital_selection import build_orbital_map"`

Additional branch-local validation, not included in the PyATB PR because it
depends on project-local cached ABACUS outputs, compared PyATB spectra against
the standalone development implementation:

- 6 non-large cases
- 39 COHP channels
- 81 reference comparisons
- 0 failures
- maximum absolute difference: `8.882e-16`

## Compatibility And Limits

- Supports `nspin = 1` and collinear `nspin = 2`.
- Rejects non-collinear `nspin = 4`.
- `spin` accepts `sum`, `up`, or `down`; `up/down` require `nspin = 2`.
- `method` accepts `COHP` or `COOP`.
- Default `invert = 1` writes bonding-positive `-COHP` style output.

## Reviewer Notes

- Confirm that the COHP/COOP sign convention matches PyATB maintainer
  expectations.
- Confirm that the current orbital-selector syntax is acceptable for ABACUS NAO
  users.
- Confirm whether `COHP` should stay under the Fermi-function documentation
  section or later move to a separate bonding-analysis section.
